### PR TITLE
fix: Gemini APIエラー時のクラッシュを修正

### DIFF
--- a/apps/ingest/src/pipeline/ai-io.ts
+++ b/apps/ingest/src/pipeline/ai-io.ts
@@ -121,12 +121,13 @@ export const callGemini = async (input: {
     });
   } catch (error) {
     if (NoObjectGeneratedError.isInstance(error)) {
-      console.log("NoObjectGeneratedError");
-      console.log("Cause:", error.cause);
-      console.log("Text:", error.text);
-      console.log("Response:", error.response);
-      console.log("Usage:", error.usage);
-      console.log("Finish Reason:", error.finishReason);
+      console.error("[callGemini] NoObjectGeneratedError");
+      console.error("Cause:", error.cause);
+      console.error("Text:", error.text);
+      console.error("Response:", error.response);
+      console.error("Usage:", error.usage);
+      console.error("Finish Reason:", error.finishReason);
     }
+    throw error;
   }
 };


### PR DESCRIPTION
  ## 概要
  `callGemini`関数で`NoObjectGeneratedError`が発生した際、エラーを再スローせずに`undefined`を返していたため、呼び出し元でクラッシュする問題を修正しました。

  ## 問題
  - `ai-io.ts`の`callGemini`関数がエラーをキャッチしてログ出力するが、再スローしていなかった
  - 結果として`undefined`が返され、`index.ts:100`の`aiResult.output`アクセス時に`TypeError`が発生
  - パイプライン全体がクラッシュし、ジョブがエラーとしてマークされない

  ## 修正内容
  - catchブロックでエラーを再スローするように変更
  - ログ出力を`console.log`から`console.error`に変更

  ## テスト
  エラー発生時に例外が再スローされ、呼び出し元のtry-catchで適切にハンドリングされることを確認しました。